### PR TITLE
Documentation for #78

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,15 @@ It was initially inspired by https://github.com/kybernetyk/tempsense
 
 ## dependencies
 
-you need a recent golang build environment, gcc and linux headers (for karalabe/hid) to build the tempsense-exporter.
+you need a recent golang build environment, gcc and libudev-dev headers (for [karalabe/hid](https://github.com/karalabe/hid)) to build the tempsense-exporter.
+
+### Ubuntu
+
+A one-liner for Ubuntu:
+
+```bash
+apt-get install golang-go build-essential libudev-dev
+```
 
 ## all
 `go build -o . ./cmd/...`


### PR DESCRIPTION
Document required packages to install for #78.

Otherwise the build will silently build a botched binary.